### PR TITLE
Form updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -619,12 +619,12 @@
         <form id="sign-form" action="https://sendto.mozilla.org/page/signup/stop-watching-us-form" method="post">
           <ul id="form-errors" class="hidden">
           </ul>
-          <input type="text" name="email" id="email" placeholder="*Email">
+          <input type="email" name="email" id="email" placeholder="*Email" required>
           <input type="text" name="firstname" id="firstname" placeholder="Full Name">
           <input type="text" name="addr1" id="addr1" placeholder="Address">
           <input type="text" name="zip" id="zip" placeholder="Zip (Optional)">
           <div class="checkbox-wrapper">
-            <input type="checkbox" name="custom-2066" id="custom-2066">
+            <input type="checkbox" name="custom-2066" id="custom-2066" required>
             <label for="custom-2066">
               * I agree to Mozilla's <a target="_blank" href="https://www.mozilla.org/en-US/privacy-policy.html">privacy policy</a> and to having my information presented to US Congress in the form of a letter to be delivered by Fight for the Future (see its <a target="_blank" href="http://www.fightforthefuture.org/privacy/">privacy policy</a>).
             </label>


### PR DESCRIPTION
- `required` for native HTML5 validation if JS is disabled
- type="email" so mobile users get the correct keyboard
