### PR TITLE
`text-align: center` on body for IE6/7

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,14 +45,15 @@
       }
 
       html, body {
-        width: 100%;
-        margin: 0;
-        padding: 0;
         background-color: rgb(245, 245, 245);
+        color: rgb(83, 83, 83);
         font-family: Georgia, 'OpenSansRegular', serif;
         font-size: 12pt;
         font-weight: normal;
-        color: rgb(83, 83, 83);
+        margin: 0;
+        padding: 0;
+        text-align: center;
+        width: 100%;
       }
 
       a {


### PR DESCRIPTION
IE6/7 don't respect `margin: 0 auto` to center content, so you need to set text-align:center on the parent node.

Also alphabetized descriptors.
